### PR TITLE
Add support for multiple languages.

### DIFF
--- a/skredvarselGarmin/resources-nob/strings.xml
+++ b/skredvarselGarmin/resources-nob/strings.xml
@@ -15,8 +15,12 @@
 	<string id="Tomorrow">I morgen</string>
 	<string id="Level">Faregrad</string>
 	<string id="FailedToFetchTheForecast">Fikk ikke til å hente varselet. Prøv å koble til telefonen på nytt.</string>
-	<string id="SeeFullForecast">Se komplett varsel på varsom.no</string>
 	<string id="FailedToCheckForSubscription">Fikk ikke til å sjekke for abonnement. Prøv å koble til telefonen på nytt.</string>
 	<string id="SeenWatchInactiveSubscription">Gå til skredvarsel.app på mobil for å tegne abonnement til appen.</string>
 	<string id="NewWatch">Logg inn på skredvarsel.app på mobilen, og legg til klokken med koden:</string>
+	<string id="UseWatchLanguage">Bruk klokkespråk i brukergrensesnitt</string>
+	<string id="ForecastLanguage">Varselspråk</string>
+	<string id="AppVersionTitle">Appversjon</string>
+	<string id="Norwegian">Norsk</string>
+	<string id="English">Engelsk</string>
 </strings>

--- a/skredvarselGarmin/resources/settings/properties.xml
+++ b/skredvarselGarmin/resources/settings/properties.xml
@@ -1,0 +1,5 @@
+<properties>
+    <property id="appVersion" type="string">1.1.0</property>
+    <property id="forecastLanguage" type="number">1</property>
+    <property id="useWatchLanguage" type="boolean">false</property>
+</properties>

--- a/skredvarselGarmin/resources/settings/settings.xml
+++ b/skredvarselGarmin/resources/settings/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+	<setting propertyKey="@Properties.appVersion" title="@Strings.AppVersionTitle">
+		<settingConfig type="alphaNumeric" readonly="true" />
+	</setting>
+	<setting propertyKey="@Properties.useWatchLanguage" title="@Strings.UseWatchLanguage">
+		<settingConfig type="boolean" />
+	</setting>
+	<setting propertyKey="@Properties.forecastLanguage" title="@Strings.ForecastLanguage">
+		<settingConfig type="list">
+			<listEntry value="1">@Strings.Norwegian</listEntry>
+			<listEntry value="2">@Strings.English</listEntry>
+		</settingConfig>
+	</setting>
+</settings>

--- a/skredvarselGarmin/resources/strings.xml
+++ b/skredvarselGarmin/resources/strings.xml
@@ -15,8 +15,12 @@
 	<string id="Tomorrow">Tomorrow</string>
 	<string id="Level">Level</string>
 	<string id="FailedToFetchTheForecast">Failed to fetch the forecast. Please try again later.</string>
-	<string id="SeeFullForecast">See complete forecast at varsom.no</string>
 	<string id="FailedToCheckForSubscription">Failed to check for subscription. Try to reconnect your phone to the watch.</string>
 	<string id="SeenWatchInactiveSubscription">Go to skredvarsel.app on mobile to sign up for the app.</string>
 	<string id="NewWatch">Log in at skredvarsel.app on mobile, and add the watch with the code:</string>
+	<string id="UseWatchLanguage">Use watch language for user interface</string>
+	<string id="ForecastLanguage">Forecast language</string>
+	<string id="AppVersionTitle">App version</string>
+	<string id="Norwegian">Norwegian</string>
+	<string id="English">English</string>
 </strings>

--- a/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastElements.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastElements.mc
@@ -57,7 +57,11 @@ public class DetailedForecastElements {
 
     _numElements = (_warning["avalancheProblems"] as Array).size() + 1;
 
-    _seeFullForecastText = Ui.loadResource($.Rez.Strings.SeeFullForecast);
+    var forecastLanguage = $.getForecastLanguage();
+    _seeFullForecastText =
+      forecastLanguage == 1
+        ? "Se komplett varsel på www.varsom.no"
+        : "See complete forecast at www.varsom.no";
 
     _elements = new [_numElements];
   }
@@ -164,7 +168,7 @@ public class DetailedForecastElements {
       if (wasNull) {
         if (i == 0) {
           _elements[i] = new AvalancheUi.MainText({
-            :text => _warning["mainText"] + " " + _seeFullForecastText,
+            :text => getMainText(),
             :width => _areaWidth,
             :height => _areaHeight,
           });
@@ -183,5 +187,30 @@ public class DetailedForecastElements {
       }
       xOffset += _fullWidth;
     }
+  }
+
+  function getMainText() {
+    var mainText = _warning["mainText"];
+
+    if (mainText == null) {
+      mainText = "";
+    }
+
+    // Remove all spaces from the end.
+    while (
+      mainText.substring(mainText.length() - 1, mainText.length()).equals(" ")
+    ) {
+      mainText = mainText.substring(0, mainText.length() - 1);
+    }
+
+    // Add a dot if it's not there in the main text.
+    if (
+      mainText.length() > 0 &&
+      !mainText.substring(mainText.length() - 1, mainText.length()).equals(".")
+    ) {
+      mainText += ".";
+    }
+
+    return mainText + " " + _seeFullForecastText;
   }
 }

--- a/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastView.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastView.mc
@@ -89,10 +89,10 @@ class DetailedForecastView extends Ui.View {
   }
 
   public function onShow() {
-    _todayText = Ui.loadResource($.Rez.Strings.Today);
-    _yesterdayText = Ui.loadResource($.Rez.Strings.Yesterday);
-    _tomorrowText = Ui.loadResource($.Rez.Strings.Tomorrow);
-    _levelText = Ui.loadResource($.Rez.Strings.Level);
+    _todayText = $.getOrLoadResourceString("I dag", :Today);
+    _yesterdayText = $.getOrLoadResourceString("I går", :Yesterday);
+    _tomorrowText = $.getOrLoadResourceString("I morgen", :Tomorrow);
+    _levelText = $.getOrLoadResourceString("Faregrad", :Level);
   }
 
   public function onUpdate(dc as Gfx.Dc) as Void {

--- a/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastViewDelegate.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastViewDelegate.mc
@@ -25,8 +25,8 @@ class DetailedForecastViewDelegate extends Ui.BehaviorDelegate {
     var favoriteRegionId = $.getFavoriteRegionId();
 
     var setAsFavoriteMenuItemText = favoriteRegionId.equals(_regionId)
-      ? $.Rez.Strings.RemoveAsFavorite
-      : $.Rez.Strings.SetAsFavorite;
+      ? $.getOrLoadResourceString("Fjern favoritt", :RemoveAsFavorite)
+      : $.getOrLoadResourceString("Sett som favoritt", :SetAsFavorite);
 
     if (selectedRegionIds.size() > 1) {
       menu.addItem(
@@ -34,7 +34,14 @@ class DetailedForecastViewDelegate extends Ui.BehaviorDelegate {
       );
     }
 
-    menu.addItem(new MenuItem($.Rez.Strings.Remove, null, "remove", {}));
+    menu.addItem(
+      new MenuItem(
+        $.getOrLoadResourceString("Fjern", :Remove),
+        null,
+        "remove",
+        {}
+      )
+    );
 
     var delegate = new DetailedForecastViewMenuDelegate(_regionId);
 

--- a/skredvarselGarmin/source/DetailedForecastsView/Menu/DetailedForecastViewMenu.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/Menu/DetailedForecastViewMenu.mc
@@ -2,6 +2,6 @@ using Toybox.WatchUi as Ui;
 
 public class DetailedForecastViewMenu extends Ui.Menu2 {
   public function initialize() {
-    Menu2.initialize({ :title => $.Rez.Strings.Edit });
+    Menu2.initialize({ :title => $.getOrLoadResourceString("Rediger", :Edit) });
   }
 }

--- a/skredvarselGarmin/source/EditMenu/EditMenu.mc
+++ b/skredvarselGarmin/source/EditMenu/EditMenu.mc
@@ -4,7 +4,9 @@ using Toybox.WatchUi as Ui;
 
 public class EditMenu extends Ui.Menu2 {
   public function initialize() {
-    Menu2.initialize({ :title => $.Rez.Strings.PickRegions });
+    Menu2.initialize({
+      :title => $.getOrLoadResourceString("Velg regioner", :PickRegions),
+    });
 
     var selectedRegionIds = $.getSelectedRegionIds() as Array<String>;
 

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenu.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenu.mc
@@ -73,7 +73,7 @@ public class ForecastMenu extends Ui.CustomMenu {
     var iconX = width / 2 - $.halfWidthDangerLevelIcon;
     dc.drawBitmap(iconX, 10, _icon);
 
-    var text = Ui.loadResource($.Rez.Strings.AppName);
+    var text = $.getOrLoadResourceString("Skredvarsel", :AppName);
     dc.drawText(
       width / 2,
       height / 2 + 15,

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenuDelegate.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenuDelegate.mc
@@ -61,7 +61,10 @@ public class ForecastMenuDelegate extends Ui.Menu2InputDelegate {
     } else if (_loadingView != null) {
       Ui.switchToView(
         new TextAreaView(
-          Ui.loadResource($.Rez.Strings.FailedToFetchTheForecast)
+          $.getOrLoadResourceString(
+            "Fikk ikke til å hente varselet. Prøv å koble til telefonen på nytt.",
+            :FailedToFetchTheForecast
+          )
         ),
         new TextAreaViewDelegate(),
         Ui.SLIDE_BLINK

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenuEditMenuItem.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenuEditMenuItem.mc
@@ -11,7 +11,7 @@ public class ForecastMenuEditMenuItem extends Ui.CustomMenuItem {
     CustomMenuItem.initialize(id, {});
 
     _screenWidth = $.getDeviceScreenWidth();
-    _text = Ui.loadResource($.Rez.Strings.PickRegions);
+    _text = $.getOrLoadResourceString("Velg regioner", :PickRegions);
   }
 
   public function draw(dc as Gfx.Dc) {

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenuItem.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenuItem.mc
@@ -31,7 +31,7 @@ public class ForecastMenuItem extends Ui.CustomMenuItem {
 
     _regionId = regionId;
     _screenWidth = $.getDeviceScreenWidth();
-    _loadingText = Ui.loadResource($.Rez.Strings.Loading);
+    _loadingText = $.getOrLoadResourceString("Laster...", :Loading);
     _useBufferedBitmaps = $.useBufferedBitmaps();
 
     getForecastFromCache();

--- a/skredvarselGarmin/source/IntermediateBaseView.mc
+++ b/skredvarselGarmin/source/IntermediateBaseView.mc
@@ -26,7 +26,10 @@ public class IntermediateBaseView extends Ui.View {
       _firstShow = false;
     }
 
-    _hitBackToExitText = Ui.loadResource($.Rez.Strings.HitBackToExit);
+    _hitBackToExitText = $.getOrLoadResourceString(
+      "Trykk tilbake for å avslutte.",
+      :HitBackToExit
+    );
   }
 
   public function onUpdate(dc as Gfx.Dc) {

--- a/skredvarselGarmin/source/LoadingView/LoadingView.mc
+++ b/skredvarselGarmin/source/LoadingView/LoadingView.mc
@@ -4,7 +4,7 @@ using Toybox.WatchUi as Ui;
 
 class LoadingView extends Ui.ProgressBar {
   public function initialize() {
-    var loadingText = Ui.loadResource($.Rez.Strings.Loading);
+    var loadingText = $.getOrLoadResourceString("Laster...", :Loading);
 
     ProgressBar.initialize(loadingText, null);
   }

--- a/skredvarselGarmin/source/ServiceDelegate.mc
+++ b/skredvarselGarmin/source/ServiceDelegate.mc
@@ -61,11 +61,13 @@ class ServiceDelegate extends System.ServiceDelegate {
   }
 
   private function reloadNextRegion() as Boolean {
+    var language = $.getForecastLanguage();
+
     if (_simpleRegionsToReload.size() > 0) {
       var nextRegion = _simpleRegionsToReload[0];
       _simpleRegionsToReload = _simpleRegionsToReload.slice(1, null);
 
-      var path = $.getSimpleWarningsPathForRegion(nextRegion);
+      var path = $.getSimpleWarningsPathForRegion(nextRegion, language);
       var storageKey = $.getSimpleForecastCacheKeyForRegion(nextRegion);
       var delegate = new WebRequestDelegate(
         path,
@@ -79,7 +81,7 @@ class ServiceDelegate extends System.ServiceDelegate {
       var nextRegion = _detailedRegionsToReload[0];
       _detailedRegionsToReload = _detailedRegionsToReload.slice(1, null);
 
-      var path = $.getDetailedWarningsPathForRegion(nextRegion);
+      var path = $.getDetailedWarningsPathForRegion(nextRegion, language);
       var storageKey = $.getDetailedWarningsCacheKeyForRegion(nextRegion);
       var delegate = new WebRequestDelegate(
         path,

--- a/skredvarselGarmin/source/SetupSubscriptionView/SetupSubscriptionView.mc
+++ b/skredvarselGarmin/source/SetupSubscriptionView/SetupSubscriptionView.mc
@@ -58,7 +58,10 @@ class SetupSubscriptionView extends Ui.View {
     if (_requestFailed) {
       if (_failedTextArea == null) {
         _failedTextArea = new Ui.TextArea({
-          :text => Ui.loadResource($.Rez.Strings.FailedToCheckForSubscription),
+          :text => $.getOrLoadResourceString(
+            "Fikk ikke til å sjekke for abonnement. Prøv å koble til telefonen på nytt.",
+            :FailedToCheckForSubscription
+          ),
           :color => Gfx.COLOR_WHITE,
           :font => [Gfx.FONT_SMALL, Gfx.FONT_XTINY],
           :locX => Ui.LAYOUT_HALIGN_CENTER,
@@ -113,7 +116,10 @@ class SetupSubscriptionView extends Ui.View {
       } else if (status.equals("SEEN_WATCH_INACTIVE_SUBSCRIPTION")) {
         Ui.switchToView(
           new NoSubscriptionView(
-            Ui.loadResource($.Rez.Strings.SeenWatchInactiveSubscription)
+            $.getOrLoadResourceString(
+              "Gå til skredvarsel.app på mobil for å tegne abonnement til appen.",
+              :SeenWatchInactiveSubscription
+            )
           ),
           null,
           Ui.SLIDE_BLINK
@@ -121,7 +127,10 @@ class SetupSubscriptionView extends Ui.View {
       } else if (status.equals("NEW_WATCH")) {
         Ui.switchToView(
           new NoSubscriptionView(
-            Ui.loadResource($.Rez.Strings.NewWatch) +
+            $.getOrLoadResourceString(
+              "Logg inn på skredvarsel.app på mobilen, og legg til klokken med koden:",
+              :NewWatch
+            ) +
               "\n\n" +
               response["addWatchKey"]
           ),

--- a/skredvarselGarmin/source/WidgetView/WidgetView.mc
+++ b/skredvarselGarmin/source/WidgetView/WidgetView.mc
@@ -31,10 +31,12 @@ public class WidgetView extends Ui.View {
 
   function onShow() {
     _regionId = $.getFavoriteRegionId();
-    _appNameText = Ui.loadResource($.Rez.Strings.AppName) as String;
-    _noRegionsSelectedText =
-      Ui.loadResource($.Rez.Strings.NoRegionsSelected) as String;
-    _loadingText = Ui.loadResource($.Rez.Strings.Loading) as String;
+    _appNameText = $.getOrLoadResourceString("Skredvarsel", :AppName);
+    _noRegionsSelectedText = $.getOrLoadResourceString(
+      "Ingen regioner valgt.",
+      :NoRegionsSelected
+    );
+    _loadingText = $.getOrLoadResourceString("Laster...", :Loading);
 
     setForecastDataFromStorage();
     if (

--- a/skredvarselGarmin/source/backend/DetailedForecastApi.mc
+++ b/skredvarselGarmin/source/backend/DetailedForecastApi.mc
@@ -15,7 +15,10 @@ function getDetailedWarningsForRegion(regionId as String) as Array? {
 }
 
 (:background)
-function getDetailedWarningsPathForRegion(regionId as String) as String {
+function getDetailedWarningsPathForRegion(
+  regionId as String,
+  language as Number
+) as String {
   var now = Time.now();
 
   var twoDays = new Time.Duration(Gregorian.SECONDS_PER_DAY * 2);
@@ -25,7 +28,9 @@ function getDetailedWarningsPathForRegion(regionId as String) as String {
   return (
     "/detailedWarningsByRegion/" +
     regionId +
-    "/1/" +
+    "/" +
+    language +
+    "/" +
     getFormattedDate(start) +
     "/" +
     getFormattedDate(end)
@@ -40,7 +45,8 @@ function loadDetailedWarningsForRegion(
     $.logMessage("Loading detailed forecast for " + regionId);
   }
 
-  var path = $.getDetailedWarningsPathForRegion(regionId);
+  var language = $.getForecastLanguage();
+  var path = $.getDetailedWarningsPathForRegion(regionId, language);
   var storageKey = $.getDetailedWarningsCacheKeyForRegion(regionId);
 
   $.makeApiRequest(path, storageKey, callback, true);

--- a/skredvarselGarmin/source/backend/SimpleForecastApi.mc
+++ b/skredvarselGarmin/source/backend/SimpleForecastApi.mc
@@ -22,7 +22,10 @@ public function getSimpleForecastForRegion(regionId as String) as Array? {
 }
 
 (:background)
-function getSimpleWarningsPathForRegion(regionId as String) as String {
+function getSimpleWarningsPathForRegion(
+  regionId as String,
+  language as Number
+) as String {
   var now = Time.now();
   var twoDays = new Time.Duration(Gregorian.SECONDS_PER_DAY * 2);
   var start = now.subtract(twoDays);
@@ -31,14 +34,16 @@ function getSimpleWarningsPathForRegion(regionId as String) as String {
   return (
     "/simpleWarningsByRegion/" +
     regionId +
-    "/1/" +
+    "/" +
+    language +
+    "/" +
     getFormattedDate(start) +
     "/" +
     getFormattedDate(end)
   );
 }
 
-(:glance)
+(:background)
 public function loadSimpleForecastForRegion(
   regionId as String?,
   callback as WebRequestDelegateCallback,
@@ -48,7 +53,8 @@ public function loadSimpleForecastForRegion(
     $.logMessage("Loading simple forecast for " + regionId);
   }
 
-  var path = $.getSimpleWarningsPathForRegion(regionId);
+  var language = $.getForecastLanguage();
+  var path = $.getSimpleWarningsPathForRegion(regionId, language);
   var storageKey = $.getSimpleForecastCacheKeyForRegion(regionId);
 
   $.makeApiRequest(path, storageKey, callback, useQueue);

--- a/skredvarselGarmin/source/backend/SkredvarselStorage.mc
+++ b/skredvarselGarmin/source/backend/SkredvarselStorage.mc
@@ -38,10 +38,21 @@ function getFavoriteRegionId() as String? {
 function resetStorageCacheIfRequired() {
   var STORAGE_VERSION = 2;
   var storageVersion = Storage.getValue("storageVersion") as Number?;
+  var cachedForecastsLanguage =
+    Storage.getValue("cachedStorageLanguage") as Number?;
+  if (cachedForecastsLanguage == null) {
+    cachedForecastsLanguage = 1; // Assume Norwegian if no value in storage
+  }
 
-  if (storageVersion == null || storageVersion != STORAGE_VERSION) {
+  var forecastLanguageSetting = $.getForecastLanguage();
+
+  if (
+    storageVersion == null ||
+    storageVersion != STORAGE_VERSION ||
+    cachedForecastsLanguage != forecastLanguageSetting
+  ) {
     if ($.Debug) {
-      $.logMessage("Wrong storage version detected. Resetting cache");
+      $.logMessage("Resetting storage cache.");
     }
 
     var hasSubscription = $.getHasSubscription();
@@ -50,6 +61,7 @@ function resetStorageCacheIfRequired() {
     setSelectedRegionIdsInStorage(selectedRegionIds);
     $.setHasSubscription(hasSubscription);
     Storage.setValue("storageVersion", STORAGE_VERSION);
+    Storage.setValue("cachedStorageLanguage", forecastLanguageSetting);
   }
 }
 

--- a/skredvarselGarmin/source/backend/WebRequestDelegate.mc
+++ b/skredvarselGarmin/source/backend/WebRequestDelegate.mc
@@ -14,7 +14,7 @@ typedef WebRequestDelegateCallback as (Method
   (responseCode as Number, data as WebRequestCallbackData) as Void
 );
 
-(:glance)
+(:background)
 function makeApiRequest(
   path as String,
   storageKey as String,

--- a/skredvarselGarmin/source/skredvarselGarminApp.mc
+++ b/skredvarselGarmin/source/skredvarselGarminApp.mc
@@ -47,6 +47,7 @@ class skredvarselGarminApp extends Application.AppBase {
     $.resetStorageCacheIfRequired();
   }
 
+  (:glance)
   private function registerTemporalEvent() {
     var lastRunTime = Background.getLastTemporalEventTime();
 
@@ -90,6 +91,8 @@ class skredvarselGarminApp extends Application.AppBase {
 
   (:glance)
   public function getGlanceView() as Lang.Array<Ui.GlanceView>? {
+    registerTemporalEvent();
+
     return [new GlanceView()];
   }
 
@@ -101,10 +104,10 @@ class skredvarselGarminApp extends Application.AppBase {
     fetchedData as Application.PersistableType
   ) as Void {
     if ($.Debug) {
-      $.logMessage("Exited background job.");
+      $.logMessage("Exited background job. Fetched data: " + fetchedData);
     }
 
-    if (fetchedData) {
+    if (fetchedData == true) {
       Ui.requestUpdate();
     }
 

--- a/skredvarselGarmin/source/utils/languageUtils.mc
+++ b/skredvarselGarmin/source/utils/languageUtils.mc
@@ -1,0 +1,36 @@
+import Toybox.Lang;
+
+using Toybox.Application;
+using Toybox.Application.Properties;
+using Toybox.WatchUi as Ui;
+
+(:glance)
+var useWatchLanguage as Boolean?;
+
+(:glance)
+function getUseWatchLanguage() as Boolean {
+  if ($.useWatchLanguage == null) {
+    $.useWatchLanguage = Properties.getValue("useWatchLanguage");
+  }
+
+  return $.useWatchLanguage;
+}
+
+(:glance)
+function getOrLoadResourceString(
+  defaultString as String,
+  resourceRef as Symbol
+) {
+  if ($.getUseWatchLanguage() == true) {
+    var strings = $.Rez.Strings as Dictionary<Symbol, Symbol>;
+
+    return Application.loadResource(strings[resourceRef]);
+  }
+
+  return defaultString;
+}
+
+(:background)
+function getForecastLanguage() as Number {
+  return Properties.getValue("forecastLanguage");
+}

--- a/skredvarselGarmin/source/utils/utils.mc
+++ b/skredvarselGarmin/source/utils/utils.mc
@@ -13,7 +13,7 @@ const DrawOutlines = false;
 (:glance)
 const TIME_TO_SHOW_LOADING = Gregorian.SECONDS_PER_DAY;
 
-(:glance)
+(:background)
 const TIME_TO_CONSIDER_DATA_STALE = Gregorian.SECONDS_PER_HOUR * 0.5;
 
 function getSortedRegionIds() as Array<String> {


### PR DESCRIPTION
* Allow users to pick the UI language, default use Norwegian but allow overriding with watch language.
* Allow users to specify forecast language in app settings.
* Trim and add a dot at the end of the maintext if it does not already contain one.
* Remove data fetching from glance since it was causing memory issues with F6Pro. Background jobs and the app itself already do enough fetching.