### PR TITLE
Use detailed warning varsom endpoint everywhere

### DIFF
--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/Mappers/DetailedAvalancheWarningMapper.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/Mappers/DetailedAvalancheWarningMapper.cs
@@ -5,6 +5,16 @@ namespace SkredvarselGarminWeb.Endpoints.Mappers;
 
 public static class DetailedAvalancheWarningMapper
 {
+    public static SimpleAvalancheWarning ToSimpleAvalancheWarning(this VarsomDetailedAvalancheWarning varsomWarning) => new()
+    {
+        DangerLevel = int.Parse(varsomWarning.DangerLevel),
+        Validity = [
+            varsomWarning.ValidFrom,
+            varsomWarning.ValidTo,
+        ],
+        HasEmergency = !string.IsNullOrWhiteSpace(varsomWarning.EmergencyWarning?.ToEmergencyWarning()),
+    };
+
     public static DetailedAvalancheWarning ToDetailedAvalancheWarning(this VarsomDetailedAvalancheWarning varsomWarning) => new()
     {
         Published = varsomWarning.PublishTime,

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/Models/SimpleAvalancheWarning.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/Models/SimpleAvalancheWarning.cs
@@ -4,4 +4,5 @@ public class SimpleAvalancheWarning
 {
     public required int DangerLevel { get; init; }
     public required DateTime[] Validity { get; init; }
+    public required bool HasEmergency { get; init; }
 }

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/VarsomApiRouteBuilderExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/VarsomApiRouteBuilderExtensions.cs
@@ -1,13 +1,31 @@
 using Microsoft.Extensions.Caching.Memory;
 using SkredvarselGarminWeb.Endpoints.Mappers;
-using SkredvarselGarminWeb.Endpoints.Models;
 using SkredvarselGarminWeb.Options;
 using SkredvarselGarminWeb.VarsomApi;
+using SkredvarselGarminWeb.VarsomApi.Models;
 
 namespace SkredvarselGarminWeb.Endpoints;
 
 public static class VarsomApiRouteBuilderExtensions
 {
+    private static async Task<IEnumerable<VarsomDetailedAvalancheWarning>> GetVarsomWarnings(
+        string regionId,
+        string langKey,
+        DateOnly from,
+        DateOnly to,
+        IVarsomApi varsomApi,
+        IMemoryCache memoryCache)
+    {
+        var cacheKey = $"VarsomWarnings_{regionId}_{langKey}_{from:yyyy-MM-dd}_{to:yyyy-MM-dd}";
+
+        return await memoryCache.GetOrCreateAsync(cacheKey, async (cacheEntry) =>
+        {
+            cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
+
+            return await varsomApi.GetDetailedWarningsByRegion(regionId, langKey, from, to);
+        }) ?? [];
+    }
+
     public static void MapVarsomApiEndpoints(this IEndpointRouteBuilder app, AuthOptions authOptions)
     {
         var simpleGet = app.MapGet("/api/simpleWarningsByRegion/{regionId}/{langKey}/{from}/{to}", async (
@@ -18,22 +36,9 @@ public static class VarsomApiRouteBuilderExtensions
             IVarsomApi varsomApi,
             IMemoryCache memoryCache) =>
         {
-            var cacheKey = $"SimpleWarnings_{regionId}_{langKey}_{from:yyyy-MM-dd}_{to:yyyy-MM-dd}";
-            return await memoryCache.GetOrCreateAsync(cacheKey, async (cacheEntry) =>
-            {
-                cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
+            var varsomWarnings = await GetVarsomWarnings(regionId, langKey, from, to, varsomApi, memoryCache);
 
-                var warnings = await varsomApi.GetWarningsByRegion(regionId, langKey, from, to);
-
-                return warnings.Select(w => new SimpleAvalancheWarning
-                {
-                    DangerLevel = int.Parse(w.DangerLevel),
-                    Validity = [
-                        w.ValidFrom,
-                        w.ValidTo
-                    ]
-                });
-            });
+            return varsomWarnings.Select(vw => vw.ToSimpleAvalancheWarning());
         });
 
         var detailedGet = app.MapGet("/api/detailedWarningsByRegion/{regionId}/{langKey}/{from}/{to}", async (
@@ -44,16 +49,9 @@ public static class VarsomApiRouteBuilderExtensions
             IVarsomApi varsomApi,
             IMemoryCache memoryCache) =>
         {
-            var cacheKey = $"DetailedWarnings_{regionId}_{langKey}_{from:yyyy-MM-dd}_{to:yyyy-MM-dd}";
+            var varsomWarnings = await GetVarsomWarnings(regionId, langKey, from, to, varsomApi, memoryCache);
 
-            return await memoryCache.GetOrCreateAsync(cacheKey, async (cacheEntry) =>
-            {
-                cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-
-                var warnings = await varsomApi.GetDetailedWarningsByRegion(regionId, langKey, from, to);
-
-                return warnings.Select(w => w.ToDetailedAvalancheWarning());
-            });
+            return varsomWarnings.Select(vw => vw.ToDetailedAvalancheWarning());
         });
 
         if (authOptions.UseWatchAuthorization)

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/VarsomApi/IVarsomApi.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/VarsomApi/IVarsomApi.cs
@@ -5,9 +5,6 @@ namespace SkredvarselGarminWeb.VarsomApi;
 
 public interface IVarsomApi
 {
-    [Get("/avalancheWarningByRegion/Simple/{regionId}/{langKey}/{from}/{to}")]
-    Task<IEnumerable<VarsomSimpleAvalancheWarning>> GetWarningsByRegion(string regionId, string langKey, DateOnly from, DateOnly to);
-
     [Get("/avalancheWarningByRegion/Detail/{regionId}/{langKey}/{from}/{to}")]
     Task<IEnumerable<VarsomDetailedAvalancheWarning>> GetDetailedWarningsByRegion(string regionId, string langKey, DateOnly from, DateOnly to);
 }


### PR DESCRIPTION
The old implementation used varsom's simple endpoint for fetching simple warnings. This is redundant since we almost always fetch the detailed warning anyway. Change so we only fetch the detailed one from Varsom and map it to simple/detailed as required for the watch.