### PR TITLE
Refactor layout of detailed forecast

### DIFF
--- a/skredvarselGarmin/source/AvalancheUi/Arrow.mc
+++ b/skredvarselGarmin/source/AvalancheUi/Arrow.mc
@@ -30,13 +30,15 @@ module AvalancheUi {
       _height = settings[:height];
       _color = settings[:color];
       _direction = settings[:direction];
+
+      createBufferedBitmap();
+    }
+
+    public function getWidth() {
+      return _width;
     }
 
     public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
-      if (_bufferedBitmap == null) {
-        createBufferedBitmap();
-      }
-
       dc.drawBitmap(x0, y0, _bufferedBitmap);
     }
 

--- a/skredvarselGarmin/source/AvalancheUi/ExposedHeightText.mc
+++ b/skredvarselGarmin/source/AvalancheUi/ExposedHeightText.mc
@@ -15,11 +15,12 @@ module AvalancheUi {
   }
 
   typedef ExposedHeightTextSettings as {
+    :dc as Gfx.Dc,
     :exposedHeight1 as Number,
     :exposedHeight2 as Number,
     :exposedHeightFill as Number,
-    :width as Numeric,
-    :height as Numeric,
+    :maxWidth as Numeric,
+    :maxHeight as Numeric,
     :dangerFillColor as Gfx.ColorType,
   };
 
@@ -27,19 +28,21 @@ module AvalancheUi {
     private var _exposedHeight1 as Number;
     private var _exposedHeight2 as Number;
     private var _exposedHeightFill as Number;
+    private var _elementSpacing as Number = 4;
 
+    private var _maxWidth as Number;
+    private var _maxHeight as Number;
+    private var _halfMaxHeight as Number;
     private var _width as Number;
-    private var _height as Number;
-    private var _halfHeight as Number;
 
     private var _font = Gfx.FONT_XTINY;
-    private var _fontHeight as Number;
+    private var _fontHeight as Number = Gfx.getFontHeight(_font);
 
-    private var _arrowHeight as Numeric;
-    private var _arrowWidth as Numeric;
+    private var _arrowHeight as Numeric = _fontHeight;
+    private var _arrowWidth as Numeric = _fontHeight * 0.66;
 
-    private var _arrows as Array<AvalancheUi.Arrow?>;
-    private var _scrollingTexts as Array<AvalancheUi.ScrollingText?>;
+    private var _arrows as Array<AvalancheUi.Arrow?> = [];
+    private var _scrollingTexts as Array<AvalancheUi.ScrollingText?> = [];
 
     private var _dangerFillColor as Gfx.ColorType;
 
@@ -48,18 +51,12 @@ module AvalancheUi {
       _exposedHeight2 = settings[:exposedHeight2];
       _exposedHeightFill = settings[:exposedHeightFill];
       _dangerFillColor = settings[:dangerFillColor];
-      _width = settings[:width];
-      _height = settings[:height];
+      _maxWidth = settings[:maxWidth];
+      _maxHeight = settings[:maxHeight];
+      _halfMaxHeight = _maxHeight / 2;
 
-      _arrows = new [2];
-      _scrollingTexts = new [2];
-
-      _halfHeight = _height / 2;
-
-      _fontHeight = Gfx.getFontHeight(_font);
-
-      _arrowHeight = _fontHeight;
-      _arrowWidth = _fontHeight * 0.66;
+      setupElements(settings[:dc]);
+      _width = getCalculatedWidth();
     }
 
     public function onShow() as Void {
@@ -86,15 +83,120 @@ module AvalancheUi {
       }
     }
 
-    public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
-      if ($.DrawOutlines) {
-        $.drawOutline(dc, x0, y0, _width, _halfHeight);
+    public function getWidth() {
+      return _width;
+    }
+
+    private function getCalculatedWidth() as Numeric {
+      if (_exposedHeightFill == 1 || _exposedHeightFill == 2) {
+        return $.max([_arrows[0].getWidth(), _scrollingTexts[0].getWidth()]);
+      } else if (_exposedHeightFill == 3) {
+        return $.max([
+          _arrows[0].getWidth() +
+            _elementSpacing +
+            _scrollingTexts[0].getWidth(),
+          _arrows[1].getWidth() +
+            _elementSpacing +
+            _scrollingTexts[1].getWidth(),
+        ]);
+      } else if (_exposedHeightFill == 4) {
+        return $.max([
+          _arrows[0].getWidth(),
+          _scrollingTexts[0].getWidth(),
+          _arrows[1].getWidth(),
+        ]);
       }
 
-      var bottomY0 = y0 + _halfHeight;
+      return 0;
+    }
+
+    private function setupElements(dc as Gfx.Dc) {
+      if (_exposedHeightFill == 1) {
+        _arrows = [createArrow(UP)];
+        _scrollingTexts = [
+          createScrollingText(
+            dc,
+            _maxWidth,
+            _halfMaxHeight,
+            Y_ALIGN_TOP,
+            _exposedHeight1 + "m"
+          ),
+        ];
+      } else if (_exposedHeightFill == 2) {
+        _scrollingTexts = [
+          createScrollingText(
+            dc,
+            _maxWidth,
+            _halfMaxHeight,
+            Y_ALIGN_BOTTOM,
+            _exposedHeight1 + "m"
+          ),
+        ];
+        _arrows = [createArrow(DOWN)];
+      } else if (_exposedHeightFill == 3) {
+        _arrows = [createArrow(UP), createArrow(DOWN)];
+        _scrollingTexts = [
+          createScrollingText(
+            dc,
+            _maxWidth - _arrowWidth - _elementSpacing,
+            _halfMaxHeight,
+            Y_ALIGN_BOTTOM,
+            _exposedHeight1 + "m"
+          ),
+          createScrollingText(
+            dc,
+            _maxWidth - _arrowWidth - _elementSpacing,
+            _halfMaxHeight,
+            Y_ALIGN_TOP,
+            _exposedHeight2 + "m"
+          ),
+        ];
+      } else if (_exposedHeightFill == 4) {
+        var text = Lang.format("$1$-$2$m", [_exposedHeight2, _exposedHeight1]);
+
+        _arrows = [createArrow(DOWN), createArrow(UP)];
+        _scrollingTexts = [
+          createScrollingText(dc, _maxWidth, _fontHeight, Y_ALIGN_CENTER, text),
+        ];
+      }
+    }
+
+    private function createArrow(direction as AvalancheUi.ArrowDirection) {
+      return new AvalancheUi.Arrow({
+        :width => _arrowWidth,
+        :height => _arrowHeight,
+        :color => _dangerFillColor,
+        :direction => direction,
+      });
+    }
+
+    private function createScrollingText(
+      dc as Gfx.Dc,
+      containerWidth as Numeric,
+      containerHeight as Numeric,
+      yAlignment as TextElementsYAlignment,
+      text as String
+    ) {
+      return new ScrollingText({
+        :dc => dc,
+        :text => text,
+        :containerWidth => containerWidth,
+        :containerHeight => containerHeight,
+        :xAlignment => X_ALIGN_LEFT,
+        :yAlignment => yAlignment,
+        :font => _font,
+      });
+    }
+
+    public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
+      if ($.DrawOutlines) {
+        $.drawOutline(dc, x0, y0, _width, _halfMaxHeight);
+      }
+
+      var bottomY0 = y0 + _halfMaxHeight;
 
       if ($.DrawOutlines) {
-        $.drawOutline(dc, x0, bottomY0, _width, _halfHeight);
+        $.drawOutline(dc, x0, bottomY0, _width, _halfMaxHeight);
       }
 
       if (_exposedHeightFill == 1) {
@@ -103,128 +205,72 @@ module AvalancheUi {
           0,
           x0,
           y0,
-          _halfHeight,
-          _width,
+          _halfMaxHeight,
           X_ALIGN_CENTER,
-          Y_ALIGN_BOTTOM,
-          UP
+          Y_ALIGN_BOTTOM
         );
-        drawScrollingText(
-          dc,
-          0,
-          x0,
-          bottomY0,
-          _halfHeight,
-          _width,
-          X_ALIGN_CENTER,
-          Y_ALIGN_TOP,
-          _exposedHeight1 + "m"
-        );
+        drawScrollingText(dc, 0, x0, bottomY0);
       } else if (_exposedHeightFill == 2) {
-        drawScrollingText(
-          dc,
-          0,
-          x0,
-          y0,
-          _halfHeight,
-          _width,
-          X_ALIGN_CENTER,
-          Y_ALIGN_BOTTOM,
-          _exposedHeight1 + "m"
-        );
+        drawScrollingText(dc, 0, x0, y0);
         drawArrow(
           dc,
           0,
           x0,
           bottomY0,
-          _halfHeight,
-          _width,
+          _halfMaxHeight,
           X_ALIGN_CENTER,
-          Y_ALIGN_TOP,
-          DOWN
+          Y_ALIGN_TOP
         );
       } else if (_exposedHeightFill == 3) {
-        var spacing = 4;
-
         drawArrow(
           dc,
           0,
           x0,
-          y0 - spacing / 2,
-          _halfHeight,
-          _width,
+          y0 - _elementSpacing / 2,
+          _halfMaxHeight,
           X_ALIGN_LEFT,
-          Y_ALIGN_BOTTOM,
-          UP
+          Y_ALIGN_BOTTOM
         );
         drawScrollingText(
           dc,
           0,
-          x0 + _arrowWidth + spacing,
-          y0 - spacing / 2,
-          _halfHeight,
-          _width - _arrowWidth - spacing,
-          X_ALIGN_LEFT,
-          Y_ALIGN_BOTTOM,
-          _exposedHeight1 + "m"
+          x0 + _arrowWidth + _elementSpacing,
+          y0 - _elementSpacing / 2
         );
         drawArrow(
           dc,
           1,
           x0,
-          bottomY0 + spacing / 2,
-          _halfHeight,
-          _width,
+          bottomY0 + _elementSpacing / 2,
+          _halfMaxHeight,
           X_ALIGN_LEFT,
-          Y_ALIGN_TOP,
-          DOWN
+          Y_ALIGN_TOP
         );
         drawScrollingText(
           dc,
           1,
-          x0 + _arrowWidth + spacing,
-          bottomY0 + spacing / 2,
-          _halfHeight,
-          _width - _arrowWidth - spacing,
-          X_ALIGN_LEFT,
-          Y_ALIGN_TOP,
-          _exposedHeight2 + "m"
+          x0 + _arrowWidth + _elementSpacing,
+          bottomY0 + _elementSpacing / 2
         );
       } else if (_exposedHeightFill == 4) {
-        var text = Lang.format("$1$-$2$m", [_exposedHeight2, _exposedHeight1]);
-
         drawArrow(
           dc,
           0,
           x0,
-          y0 + _height / 2 - _fontHeight - _fontHeight / 2,
+          y0 + _maxHeight / 2 - _fontHeight - _fontHeight / 2,
           _fontHeight,
-          _width,
           X_ALIGN_CENTER,
-          Y_ALIGN_BOTTOM,
-          DOWN
+          Y_ALIGN_BOTTOM
         );
-        drawScrollingText(
-          dc,
-          0,
-          x0,
-          y0 + _height / 2 - _fontHeight / 2,
-          _fontHeight,
-          _width,
-          X_ALIGN_CENTER,
-          Y_ALIGN_CENTER,
-          text
-        );
+        drawScrollingText(dc, 0, x0, y0 + _maxHeight / 2 - _fontHeight / 2);
         drawArrow(
           dc,
           1,
           x0,
-          y0 + _height / 2 + _fontHeight / 2,
+          y0 + _maxHeight / 2 + _fontHeight / 2,
           _fontHeight,
-          _width,
           X_ALIGN_CENTER,
-          Y_ALIGN_TOP,
-          UP
+          Y_ALIGN_TOP
         );
       }
     }
@@ -233,24 +279,8 @@ module AvalancheUi {
       dc as Gfx.Dc,
       textIndex as Number,
       x0 as Numeric,
-      y0 as Numeric,
-      height as Numeric,
-      width as Numeric,
-      xAlignment as TextElementsXAlignment,
-      yAlignment as TextElementsYAlignment,
-      text as String
+      y0 as Numeric
     ) {
-      if (_scrollingTexts[textIndex] == null) {
-        _scrollingTexts[textIndex] = new AvalancheUi.ScrollingText({
-          :text => text,
-          :containerWidth => width,
-          :containerHeight => height,
-          :xAlignment => xAlignment,
-          :yAlignment => yAlignment,
-          :font => _font,
-        });
-      }
-
       _scrollingTexts[textIndex].draw(dc, x0, y0);
     }
 
@@ -259,27 +289,17 @@ module AvalancheUi {
       arrowIndex as Number,
       x0 as Numeric,
       y0 as Numeric,
-      height as Numeric,
-      width as Numeric,
+      containerHeight as Numeric,
       xAlignment as TextElementsXAlignment,
-      yAlignment as TextElementsYAlignment,
-      direction as AvalancheUi.ArrowDirection
+      yAlignment as TextElementsYAlignment
     ) {
-      if (_arrows[arrowIndex] == null) {
-        _arrows[arrowIndex] = new AvalancheUi.Arrow({
-          :width => _arrowWidth,
-          :height => _arrowHeight,
-          :color => _dangerFillColor,
-          :direction => direction,
-        });
-      }
-
       var arrowXOffset = 0;
       if (xAlignment == X_ALIGN_CENTER) {
-        arrowXOffset = width / 2 - _arrowWidth / 2;
+        arrowXOffset = _width / 2 - _arrowWidth / 2;
       }
 
-      var arrowYOffset = yAlignment == Y_ALIGN_TOP ? 0 : height - _arrowHeight;
+      var arrowYOffset =
+        yAlignment == Y_ALIGN_TOP ? 0 : containerHeight - _arrowHeight;
       _arrows[arrowIndex].draw(dc, x0 + arrowXOffset, y0 + arrowYOffset);
     }
   }

--- a/skredvarselGarmin/source/AvalancheUi/ValidExpositions.mc
+++ b/skredvarselGarmin/source/AvalancheUi/ValidExpositions.mc
@@ -13,49 +13,36 @@ module AvalancheUi {
   };
 
   public class ValidExpositions {
-    private var _validExpositions as Array<Char>;
     private var _radius as Numeric;
+    private var _font as Ui.Resource = Ui.loadResource($.Rez.Fonts.roboto);
+    private var _fontHeight as Number = Gfx.getFontHeight(_font);
 
-    private var _font as Ui.Resource;
-    private var _fontHeight as Number;
-
-    private var _dangerFillColor as Gfx.ColorType;
-    private var _nonDangerFillColor as Gfx.ColorType;
-
-    private var _bufferedBitmap as Gfx.BufferedBitmap?;
+    private var _bufferedBitmap as Gfx.BufferedBitmap;
 
     public function initialize(settings as ValidExpositionsSettings) {
-      _validExpositions = settings[:validExpositions].toCharArray();
-      _radius = settings[:radius] as Numeric;
-      _dangerFillColor = settings[:dangerFillColor];
-      _nonDangerFillColor = settings[:nonDangerFillColor];
+      _radius = settings[:radius];
 
-      _font = WatchUi.loadResource($.Rez.Fonts.roboto);
-      _fontHeight = Gfx.getFontHeight(_font);
+      _bufferedBitmap = createBufferedBitmap(settings);
+    }
 
-      var numChars = _validExpositions.size();
+    private function createBufferedBitmap(
+      settings as ValidExpositionsSettings
+    ) as Gfx.BufferedBitmap {
+      var validExpositions = settings[:validExpositions].toCharArray();
+      var numChars = validExpositions.size();
       if (numChars != 8) {
         throw new SkredvarselGarminException(
           "Invalid char array for valid expositions."
         );
       }
-    }
-
-    public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
-      if (_bufferedBitmap == null) {
-        createBufferedBitmap();
-      }
-
-      dc.drawBitmap(x0 - _radius, y0 - _radius - _fontHeight, _bufferedBitmap);
-    }
-
-    private function createBufferedBitmap() {
-      _bufferedBitmap = $.newBufferedBitmap({
+      var dangerFillColor = settings[:dangerFillColor];
+      var nonDangerFillColor = settings[:nonDangerFillColor];
+      var bufferedBitmap = $.newBufferedBitmap({
         :width => _radius * 2,
         :height => _radius * 2 + _fontHeight,
       });
 
-      var bufferedDc = _bufferedBitmap.getDc();
+      var bufferedDc = bufferedBitmap.getDc();
 
       bufferedDc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
       bufferedDc.drawText(
@@ -82,14 +69,14 @@ module AvalancheUi {
 
       // Draw cake slices
       for (var i = 0; i < 8; i++) {
-        var currChar = _validExpositions[i];
+        var currChar = validExpositions[i];
 
         var endAngle = (startAngle - anglePerChar) % 360;
 
         if (currChar == '0') {
-          bufferedDc.setColor(_nonDangerFillColor, _nonDangerFillColor);
+          bufferedDc.setColor(nonDangerFillColor, nonDangerFillColor);
         } else {
-          bufferedDc.setColor(_dangerFillColor, _dangerFillColor);
+          bufferedDc.setColor(dangerFillColor, dangerFillColor);
         }
 
         bufferedDc.drawArc(
@@ -119,6 +106,18 @@ module AvalancheUi {
         bufferedDc.drawLine(start[0], start[1], end[0], end[1]);
         startAngle = (startAngle + 45) % 360;
       }
+
+      return bufferedBitmap;
+    }
+
+    public function getSize() {
+      return _radius * 2;
+    }
+
+    public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
+      var Y0 = y0 - _fontHeight;
+
+      dc.drawBitmap(x0, Y0, _bufferedBitmap);
     }
   }
 

--- a/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastFooter.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastFooter.mc
@@ -16,12 +16,11 @@ typedef DetailedForecastFooterSettings as {
 public class DetailedForecastFooter {
   private var _publishedTime as String?;
   private var _locX as Numeric;
-  private var _locY as Numeric;
   private var _width as Numeric;
   private var _height as Numeric;
 
   private var _font = Gfx.FONT_XTINY;
-  private var _fontHeight as Number;
+  private var _fontHeight as Number = Gfx.getFontHeight(_font);
 
   private var _bufferedBitmap as Gfx.BufferedBitmap?;
   private var _bufferedBitmapWidth as Numeric?;
@@ -30,20 +29,14 @@ public class DetailedForecastFooter {
   private var _isLoading as Boolean;
   private var _loadingSpinner as AvalancheUi.LoadingSpinner?;
 
-  private var _deviceScreenWidth as Number;
+  private var _deviceScreenWidth as Number = $.getDeviceScreenWidth();
 
   public function initialize(settings as DetailedForecastFooterSettings) {
     _publishedTime = settings[:publishedTime];
-
     _locX = settings[:locX];
-    _locY = settings[:locY];
     _width = settings[:width];
     _height = settings[:height];
     _isLoading = settings[:isLoading];
-
-    _fontHeight = Gfx.getFontHeight(_font);
-
-    _deviceScreenWidth = $.getDeviceScreenWidth();
   }
 
   public function onTick() {
@@ -52,12 +45,12 @@ public class DetailedForecastFooter {
     }
   }
 
-  public function draw(dc as Gfx.Dc) {
+  public function draw(dc as Gfx.Dc, y0 as Numeric) {
     if (_isLoading) {
       if (_loadingSpinner == null) {
         _loadingSpinner = new AvalancheUi.LoadingSpinner({
           :locX => _locX + _width / 2.0,
-          :locY => _locY + _height / 2.0,
+          :locY => y0 + _height / 2.0,
           :radius => _fontHeight / 2.0,
         });
       }
@@ -110,7 +103,7 @@ public class DetailedForecastFooter {
     if (_bufferedBitmap != null) {
       var textX0 = _locX + _width / 2.0 - _bufferedBitmapWidth / 2.0;
       var textY0 =
-        _deviceScreenWidth > 240 ? _locY + _bufferedBitmapHeight / 2.0 : _locY;
+        _deviceScreenWidth > 240 ? y0 + _bufferedBitmapHeight / 2.0 : y0;
 
       dc.drawBitmap(textX0, textY0, _bufferedBitmap);
     }

--- a/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastHeader.mc
+++ b/skredvarselGarmin/source/DetailedForecastsView/DetailedForecastHeader.mc
@@ -3,6 +3,7 @@ import Toybox.Lang;
 using Toybox.Graphics as Gfx;
 
 typedef DetailedForecastHeaderSettings as {
+  :dc as Gfx.Dc,
   :regionName as String,
   :validityDate as String,
   :locX as Numeric,
@@ -21,13 +22,13 @@ public class DetailedForecastHeader {
   private var _height as Numeric;
 
   private var _font = Gfx.FONT_XTINY;
-  private var _fontHeight as Number;
+  private var _fontHeight as Number = Gfx.getFontHeight(_font);
 
   private var _bufferedBitmapText as Gfx.BufferedBitmap?;
   private var _bufferedBitmapWidth as Numeric?;
   private var _bufferedBitmapHeight as Numeric?;
 
-  private var _deviceScreenWidth as Numeric;
+  private var _deviceScreenWidth as Numeric = $.getDeviceScreenWidth();
 
   public function initialize(settings as DetailedForecastFooterSettings) {
     _regionName = settings[:regionName];
@@ -37,40 +38,38 @@ public class DetailedForecastHeader {
     _width = settings[:width];
     _height = settings[:height];
 
-    _fontHeight = Gfx.getFontHeight(_font);
+    setupBufferedBitmaps(settings[:dc]);
+  }
 
-    _deviceScreenWidth = $.getDeviceScreenWidth();
+  private function setupBufferedBitmaps(dc as Gfx.Dc) {
+    var text = _validityDate;
+
+    if (_deviceScreenWidth > 240) {
+      text = Lang.format("$1$\n$2$", [text, _regionName]);
+    }
+
+    var textDimensions = dc.getTextDimensions(text, _font);
+
+    _bufferedBitmapWidth = textDimensions[0];
+    _bufferedBitmapHeight = textDimensions[1];
+
+    _bufferedBitmapText = $.newBufferedBitmap({
+      :width => _bufferedBitmapWidth,
+      :height => _bufferedBitmapHeight,
+    });
+    var bufferedDc = _bufferedBitmapText.getDc();
+    bufferedDc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
+
+    bufferedDc.drawText(
+      textDimensions[0] / 2,
+      textDimensions[1] / 2,
+      _font,
+      text,
+      Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
+    );
   }
 
   public function draw(dc as Gfx.Dc) {
-    if (_bufferedBitmapText == null) {
-      var text = _validityDate;
-
-      if (_deviceScreenWidth > 240) {
-        text = Lang.format("$1$\n$2$", [text, _regionName]);
-      }
-
-      var textDimensions = dc.getTextDimensions(text, _font);
-
-      _bufferedBitmapWidth = textDimensions[0];
-      _bufferedBitmapHeight = textDimensions[1];
-
-      _bufferedBitmapText = $.newBufferedBitmap({
-        :width => _bufferedBitmapWidth,
-        :height => _bufferedBitmapHeight,
-      });
-      var bufferedDc = _bufferedBitmapText.getDc();
-      bufferedDc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
-
-      bufferedDc.drawText(
-        textDimensions[0] / 2,
-        textDimensions[1] / 2,
-        _font,
-        text,
-        Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
-      );
-    }
-
     var textX0 = _locX + _width / 2 - _bufferedBitmapWidth / 2;
     var textYOffset =
       _deviceScreenWidth > 240 ? 0 : _height / 2 - _fontHeight / 2;

--- a/skredvarselGarmin/source/utils/utils.mc
+++ b/skredvarselGarmin/source/utils/utils.mc
@@ -259,6 +259,17 @@ function min(a as Numeric, b as Numeric) {
   return a < b ? a : b;
 }
 
+function max(arr as Array<Numeric>) {
+  var max = arr[0];
+  for (var i = 0; i < arr.size(); i++) {
+    if (arr[i] > max) {
+      max = arr[i];
+    }
+  }
+
+  return max;
+}
+
 (:background)
 public function getDangerLevelToday(
   forecast as SimpleAvalancheForecast


### PR DESCRIPTION
Refactor the layout of the detailed forecast elements so there is even spacing between the elements. This required pre-calculating the width of the scrolling texts so the padding between elements can be pre-calculated before drawing. Also refactor other related code to create bitmaps immediately instead of when drawing, this simplifies the drawing code significantly and ensures the bitmap creation is done only once.