### PR TITLE
Rework agreement charges.

### DIFF
--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Database/DbContextAgreementExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Database/DbContextAgreementExtensions.cs
@@ -8,6 +8,12 @@ public static class DbContextAgreementExtensions
     public static List<Agreement> GetAgreementsThatAreDue(this SkredvarselDbContext dbContext, IDateTimeNowProvider dateTimeNowProvider) =>
         [.. dbContext.Agreements.Where(a => DateOnly.FromDateTime(dateTimeNowProvider.UtcNow) >= a.NextChargeDate)];
 
+    public static List<Agreement> GetAgreementsDueInLessThan30Days(this SkredvarselDbContext dbContext, IDateTimeNowProvider dateTimeNowProvider) =>
+        [.. dbContext.Agreements.Where(a => a.NextChargeDate.GetValueOrDefault().DayNumber - DateOnly.FromDateTime(dateTimeNowProvider.UtcNow).DayNumber <= 30)];
+
+    public static List<Agreement> GetAgreementsDueInLessThan30DaysWithoutNextChargeId(this SkredvarselDbContext dbContext, IDateTimeNowProvider dateTimeNowProvider) =>
+        [.. dbContext.Agreements.Where(a => a.NextChargeId == null && a.NextChargeDate.GetValueOrDefault().DayNumber - DateOnly.FromDateTime(dateTimeNowProvider.UtcNow).DayNumber <= 30)];
+
     public static List<Agreement> GetPendingAgreements(this SkredvarselDbContext dbContext) =>
         [.. dbContext.Agreements.Where(a => a.Status == AgreementStatus.PENDING)];
 

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Agreement.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Agreement.cs
@@ -16,7 +16,7 @@ public class Agreement
     public required DateOnly Start { get; set; }
 
     public string? NextChargeId { get; set; }
-    public DateOnly? NextChargeDate { get; set; }
+    public required DateOnly? NextChargeDate { get; set; }
     public int? NextChargeAmount { get; set; }
 
     public required string UserId { get; set; }

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Extensions/AgreementExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Extensions/AgreementExtensions.cs
@@ -12,6 +12,7 @@ public static class AgreementExtensions
     {
         agreement.Status = AgreementStatus.STOPPED;
         agreement.NextChargeDate = null;
+        agreement.NextChargeAmount = null;
         agreement.NextChargeId = null;
     }
 }

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Program.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Program.cs
@@ -10,7 +10,6 @@ using SkredvarselGarminWeb.Helpers;
 using SkredvarselGarminWeb.Services;
 using Microsoft.AspNetCore.DataProtection;
 using Stripe;
-using NetTopologySuite.IO.Converters;
 using Microsoft.OpenApi.Models;
 using SkredvarselGarminWeb.Middlewares;
 
@@ -59,6 +58,7 @@ builder.Services.AddRefitClients(vippsOptions!);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.CustomSchemaIds(type => type.ToString());
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "SkredvarselGarminWeb", Version = "v1" });
 });
 
@@ -111,6 +111,8 @@ using (var scope = app.Services.CreateScope())
     recurringJobManager.AddOrUpdate<HangfireService>("RemoveStaleWatchAddRequests", s => s.RemoveStaleWatchAddRequests(), "*/5 * * * *");
     recurringJobManager.AddOrUpdate<HangfireService>("RemoveStaleUsers", s => s.RemoveStaleUsers(), "0 3 * * *");
     recurringJobManager.AddOrUpdate<HangfireService>("PopulateNextChargeAmount", s => s.PopulateNextChargeAmount(), Cron.Never);
+    recurringJobManager.AddOrUpdate<HangfireService>("RemoveChargesOlderThan180Days", s => s.RemoveChargesOlderThan180Days(), Cron.Never);
+    recurringJobManager.AddOrUpdate<HangfireService>("CreateNextChargeForAgreement", s => s.CreateNextChargeForAgreement(), Cron.Hourly);
 }
 
 if (app.Environment.IsDevelopment())

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/IVippsAgreementService.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/IVippsAgreementService.cs
@@ -6,4 +6,9 @@ public interface IVippsAgreementService
     Task DeactivateAgreement(string agreementId);
     Task ReactivateAgreement(string agreementId);
     Task PopulateNextChargeAmount(string agreementId);
+
+    // TODO: Remove
+    Task RemoveNextChargeOlderThan180Days(string agreementId);
+
+    Task CreateNextChargeForAgreement(string agreementId);
 }


### PR DESCRIPTION
Apparently it is not possible to capture charges that are older than 180 days old. This required a rework of how we handle agreement charges.

The previous implementation automatically created a new charge when the old one was captured, but this is not sufficient if the next charge is more than 180 days into the future. The new implementation creates charges in a separate job only when the agreement is due within 30 days.

Rework the tests and the code to work with the new flow.