### PR TITLE
Fix bug where agreements could be charged in error

### DIFF
--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Database/DbContextAgreementExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Database/DbContextAgreementExtensions.cs
@@ -33,9 +33,6 @@ public static class DbContextAgreementExtensions
     public static Agreement? GetAgreementWithCallbackId(this SkredvarselDbContext dbContext, Guid callbackId) =>
         dbContext.Agreements.SingleOrDefault(a => a.CallbackId == callbackId);
 
-    public static List<Agreement> GetPendingAgreements(this SkredvarselDbContext dbContext) =>
-        [.. dbContext.Agreements.Where(a => a.Status == AgreementStatus.PENDING)];
-
     public static bool DoesUserHaveActiveSubscription(this SkredvarselDbContext dbContext, string userId)
     {
         var activeOrUnsubbedVippsAgreements = dbContext.Agreements


### PR DESCRIPTION
The previous implementation could result in agreements being set as active before they received a callback. So users could end up creating multiple agreements and being charged for them. Avoid this by not setting agreements as active before the user comes back from Vipps. If an agreement has not come back from Vipps within 15 minutes, remove it.