### PR TITLE
Charge new subscription synchronously.

### DIFF
--- a/SkredvarselGarminWeb/.vscode/launch.json
+++ b/SkredvarselGarminWeb/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/SkredvarselGarminWeb/bin/Debug/net7.0/SkredvarselGarminWeb.dll",
+      "program": "${workspaceFolder}/SkredvarselGarminWeb/bin/Debug/net9.0/SkredvarselGarminWeb.dll",
       "args": [],
       "cwd": "${workspaceFolder}/SkredvarselGarminWeb",
       "stopAtEntry": false,

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/VippsSubscriptionEndpointsRouteBuilderExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/VippsSubscriptionEndpointsRouteBuilderExtensions.cs
@@ -238,7 +238,15 @@ public static class VippsSubscriptionEndpointsRouteBuilderExtensions
                         agreement.SetAsActive();
                         agreement.RemoveCallbackId();
 
-                        backgroundJobClient.Enqueue(() => subscriptionService.UpdateAgreementCharges(agreement.Id));
+                        try
+                        {
+                            await subscriptionService.UpdateAgreementCharges(agreement.Id);
+                        }
+                        catch (Exception e)
+                        {
+                            logger.LogError(e, "Failed to update agreement charges for agreement {agreementId}. Retrying via Hangfire.", agreement.Id);
+                            backgroundJobClient.Enqueue(() => subscriptionService.UpdateAgreementCharges(agreement.Id));
+                        }
                     }
                     catch (Exception e)
                     {

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/AccountPage/Subscription.tsx
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/AccountPage/Subscription.tsx
@@ -44,7 +44,7 @@ export const Subscription = () => {
         <Text mb={2}>Du har ikke registrert et abonnement på appen.</Text>
 
         <VStack gap={5} alignItems="stretch">
-          <VippsButton />
+          <VippsButton text="Kjøp abonnement med" />
           <Box position="relative">
             <Divider />
             <AbsoluteCenter bg="white" px="4">

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/VippsAgreementService.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/VippsAgreementService.cs
@@ -81,11 +81,20 @@ public class VippsAgreementService(
     [DisableConcurrentExecution(10)]
     public async Task UpdateAgreementCharges(string agreementId)
     {
-        using var transaction = dbContext.Database.BeginTransaction();
+        var isExistingTransaction = dbContext.Database.CurrentTransaction != null;
 
-        await UpdateAgreementChargesInternal(agreementId);
+        if (!isExistingTransaction)
+        {
+            using var transaction = dbContext.Database.BeginTransaction();
 
-        transaction.Commit();
+            await UpdateAgreementChargesInternal(agreementId);
+
+            transaction.Commit();
+        }
+        else
+        {
+            await UpdateAgreementChargesInternal(agreementId);
+        }
     }
 
     private async Task UpdateAgreementChargesInternal(string agreementId)


### PR DESCRIPTION
To avoid stale information ending up in the UI, immediately attempt to charge new subscriptions when they are created. If this fails, fall back to the old behavior via Hangfire. Also update texts for Vipps buttons slightly.