### PR TITLE
Add support for location based forecast.

### DIFF
--- a/skredvarselGarmin/manifest.xml
+++ b/skredvarselGarmin/manifest.xml
@@ -85,6 +85,7 @@
       <iq:uses-permission id="Background"/>
       <iq:uses-permission id="Communications"/>
       <iq:uses-permission id="ComplicationPublisher"/>
+      <iq:uses-permission id="Positioning"/>
     </iq:permissions>
     <!--
             Use "Monkey C: Edit Languages" from the Visual Studio Code command

--- a/skredvarselGarmin/resources-nob/strings.xml
+++ b/skredvarselGarmin/resources-nob/strings.xml
@@ -28,4 +28,5 @@
 	<string id="ComplicationLongLabel">Skredfare</string>
 	<string id="ComplicationShortLabel">Ava</string>
 	<string id="Updated">Oppdatert</string>
+	<string id="UseLocation">Bruk klokkeposisjon for å hente nærmeste skredvarsel.</string>
 </strings>

--- a/skredvarselGarmin/resources/settings/properties.xml
+++ b/skredvarselGarmin/resources/settings/properties.xml
@@ -1,5 +1,6 @@
 <properties>
-    <property id="appVersion" type="string">1.3.0</property>
+    <property id="appVersion" type="string">2.0</property>
+    <property id="useLocation" type="boolean">true</property>
     <property id="forecastLanguage" type="number">1</property>
     <property id="useWatchLanguage" type="boolean">false</property>
 </properties>

--- a/skredvarselGarmin/resources/settings/settings.xml
+++ b/skredvarselGarmin/resources/settings/settings.xml
@@ -2,6 +2,9 @@
 	<setting propertyKey="@Properties.appVersion" title="@Strings.AppVersionTitle">
 		<settingConfig type="alphaNumeric" readonly="true" />
 	</setting>
+	<setting propertyKey="@Properties.useLocation" title="@Strings.UseLocation">
+		<settingConfig type="boolean" />
+	</setting>
 	<setting propertyKey="@Properties.useWatchLanguage" title="@Strings.UseWatchLanguage">
 		<settingConfig type="boolean" />
 	</setting>

--- a/skredvarselGarmin/resources/strings.xml
+++ b/skredvarselGarmin/resources/strings.xml
@@ -28,4 +28,5 @@
 	<string id="ComplicationLongLabel">Avalanche</string>
 	<string id="ComplicationShortLabel">Ava</string>
 	<string id="Updated">Updated</string>
+	<string id="UseLocation">Use watch location to show closest forecast.</string>
 </strings>

--- a/skredvarselGarmin/source/AvalancheUi/ForecastTimeline.mc
+++ b/skredvarselGarmin/source/AvalancheUi/ForecastTimeline.mc
@@ -12,11 +12,13 @@ module AvalancheUi {
     :regionId as String,
     :regionName as String,
     :forecast as SimpleAvalancheForecast,
+    :isLocationForecast as Boolean,
   };
 
   (:glance)
   class ForecastTimeline {
     private var _forecast as SimpleAvalancheForecast;
+    private var _isLocationForecast as Boolean;
 
     private var _numWarnings;
 
@@ -26,8 +28,10 @@ module AvalancheUi {
     private var _lineHeight = 8;
 
     private var _markerWidth = 3;
-    private var _markerHeight = 18;
+    private var _markerHeight = 16;
     private var _strokeOffset = 4;
+
+    private var _navigationIconGap = 4;
 
     private var _oneDayValue = $.dayDuration(1).value().toFloat();
 
@@ -43,6 +47,8 @@ module AvalancheUi {
     private var _dangerLevelFont = Gfx.FONT_GLANCE;
 
     private var _regionName as String?;
+
+    private var _navigationIcon as AvalancheUi.NavigationIcon?;
 
     public function initialize(settings as ForecastTimelineSettings) {
       _locX = settings[:locX];
@@ -60,6 +66,22 @@ module AvalancheUi {
         :currentTimeType => Time.CURRENT_TIME_DEFAULT,
       });
       _earlyCutoffTime = $.subtractDays(now, 2);
+      _isLocationForecast =
+        settings[:isLocationForecast] != null
+          ? settings[:isLocationForecast]
+          : false;
+
+      if (_isLocationForecast) {
+        var navigationIconSize = 13;
+
+        var screenWidth = $.getDeviceScreenWidth();
+        if (screenWidth > 260) {
+          navigationIconSize = 20;
+          _navigationIconGap = 6;
+        }
+
+        _navigationIcon = new AvalancheUi.NavigationIcon(navigationIconSize);
+      }
     }
 
     public function draw(dc as Gfx.Dc) {
@@ -151,6 +173,11 @@ module AvalancheUi {
     private function drawTitle(dc as Gfx.Dc, x0 as Number, y0 as Number) {
       dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_TRANSPARENT);
 
+      var textDimensions = dc.getTextDimensions(
+        _regionName,
+        Graphics.FONT_GLANCE
+      );
+
       dc.drawText(
         x0,
         y0,
@@ -158,6 +185,13 @@ module AvalancheUi {
         _regionName,
         Graphics.TEXT_JUSTIFY_LEFT
       );
+
+      if (_navigationIcon != null) {
+        var minX = textDimensions[0] + _navigationIconGap;
+        var minY = textDimensions[1] / 2 - _navigationIcon.size / 2;
+
+        _navigationIcon.draw(dc, x0 + minX, y0 + minY);
+      }
     }
 
     private function drawMarker(

--- a/skredvarselGarmin/source/AvalancheUi/NavigationIcon.mc
+++ b/skredvarselGarmin/source/AvalancheUi/NavigationIcon.mc
@@ -1,0 +1,47 @@
+import Toybox.Lang;
+
+using Toybox.Graphics as Gfx;
+
+module AvalancheUi {
+  (:glance)
+  public class NavigationIcon {
+    private var _bufferedBitmap as Gfx.BufferedBitmap?;
+    public var size as Number;
+
+    public function initialize(initSize as Number) {
+      size = initSize;
+
+      _bufferedBitmap = $.newBufferedBitmap({
+        :width => size,
+        :height => size,
+        :palette => [Gfx.COLOR_TRANSPARENT, Gfx.COLOR_BLUE],
+      });
+
+      var bufferedDc = _bufferedBitmap.getDc();
+
+      bufferedDc.setColor(Gfx.COLOR_BLUE, Gfx.COLOR_TRANSPARENT);
+      bufferedDc.fillPolygon(getPoints());
+    }
+
+    public function draw(dc as Gfx.Dc, x0 as Numeric, y0 as Numeric) {
+      dc.drawBitmap(x0, y0, _bufferedBitmap);
+    }
+
+    private function getPoints() {
+      var scale = size / 100.0;
+
+      return [
+        [87.13 * scale, 0.0 * scale],
+        [86.49 * scale, 0.09 * scale],
+        [85.61 * scale, 0.55 * scale],
+        [11.34 * scale, 62.37 * scale],
+        [12.96 * scale, 66.59 * scale],
+        [50.92 * scale, 65.11 * scale],
+        [68.62 * scale, 98.73 * scale],
+        [73.08 * scale, 98.02 * scale],
+        [89.48 * scale, 2.79 * scale],
+        [87.14 * scale, 0.0 * scale],
+      ];
+    }
+  }
+}

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenu.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenu.mc
@@ -28,12 +28,20 @@ public class ForecastMenu extends Ui.CustomMenu {
   }
 
   function onShow() {
-    var regionIds = $.getSelectedRegionIds();
-    var numRegions = regionIds.size();
+    var selectedRegionIds = $.getSelectedRegionIds();
+    var numRegions = selectedRegionIds.size();
 
     if (numRegions == 0) {
-      _existingRegionIds = regionIds;
+      _existingRegionIds = selectedRegionIds;
       deleteAllItems();
+
+      var useLocation = $.getUseLocation();
+      if (useLocation) {
+        addItem(
+          new ForecastMenuItem({ :menu => self, :isLocationForecast => true })
+        );
+      }
+
       addItem(new ForecastMenuEditMenuItem(_editItemId));
       redrawTitleAndFooter();
       return;
@@ -43,8 +51,8 @@ public class ForecastMenu extends Ui.CustomMenu {
     if (numRegions != _existingRegionIds.size()) {
       regionsChanged = true;
     } else {
-      for (var i = 0; i < regionIds.size(); i++) {
-        if (!regionIds[i].equals(_existingRegionIds[i])) {
+      for (var i = 0; i < selectedRegionIds.size(); i++) {
+        if (!selectedRegionIds[i].equals(_existingRegionIds[i])) {
           regionsChanged = true;
           break;
         }
@@ -53,8 +61,21 @@ public class ForecastMenu extends Ui.CustomMenu {
 
     if (regionsChanged) {
       deleteAllItems();
-      for (var i = 0; i < regionIds.size(); i++) {
-        addItem(new ForecastMenuItem(self, regionIds[i]));
+
+      var useLocation = $.getUseLocation();
+      if (useLocation) {
+        addItem(
+          new ForecastMenuItem({ :menu => self, :isLocationForecast => true })
+        );
+      }
+
+      for (var i = 0; i < selectedRegionIds.size(); i++) {
+        addItem(
+          new ForecastMenuItem({
+            :menu => self,
+            :regionId => selectedRegionIds[i],
+          })
+        );
       }
 
       addItem(new ForecastMenuEditMenuItem(_editItemId));
@@ -62,7 +83,7 @@ public class ForecastMenu extends Ui.CustomMenu {
       redrawTitleAndFooter();
     }
 
-    _existingRegionIds = regionIds;
+    _existingRegionIds = selectedRegionIds;
   }
 
   function drawTitle(dc as Gfx.Dc) {

--- a/skredvarselGarmin/source/ForecastMenu/ForecastMenuDelegate.mc
+++ b/skredvarselGarmin/source/ForecastMenu/ForecastMenuDelegate.mc
@@ -22,7 +22,7 @@ public class ForecastMenuDelegate extends Ui.Menu2InputDelegate {
         WatchUi.SLIDE_LEFT
       );
     } else {
-      _regionId = (item as ForecastMenuItem).regionId;
+      _regionId = (item as ForecastMenuItem).getRegionId();
 
       var data = $.getDetailedWarningsForRegion(_regionId);
 

--- a/skredvarselGarmin/source/backend/SimpleForecastApi.mc
+++ b/skredvarselGarmin/source/backend/SimpleForecastApi.mc
@@ -8,7 +8,7 @@ using Toybox.Application.Storage;
 public function getSimpleForecastForRegion(regionId as String) as Array? {
   var storageKey = $.getSimpleForecastCacheKeyForRegion(regionId);
 
-  return Storage.getValue(storageKey);
+  return Storage.getValue(storageKey) as Array?;
 }
 
 (:background)
@@ -41,6 +41,61 @@ public function loadSimpleForecastForRegion(
 
   var path = $.getSimpleWarningsPathForRegion(regionId, language, start, end);
   var storageKey = $.getSimpleForecastCacheKeyForRegion(regionId);
+
+  $.makeApiRequest(path, storageKey, callback, useQueue);
+}
+
+(:background)
+function getSimpleWarningsPathForLocation(
+  latitude as Double,
+  longitude as Double,
+  language as Number,
+  formattedStartDate as String,
+  formattedEndDate as String
+) as String {
+  return Lang.format("/simpleWarningsByLocation/$1$/$2$/$3$/$4$/$5$", [
+    latitude,
+    longitude,
+    language,
+    formattedStartDate,
+    formattedEndDate,
+  ]);
+}
+
+// Returns [forecast, storedTime] array
+(:glance,:background)
+public function getSimpleForecastForLocation() as Array? {
+  var storageKey = $.simpleForecastCacheKeyForLocation;
+
+  return Storage.getValue(storageKey) as Array?;
+}
+
+public function loadSimpleForecastForLocation(
+  callback as WebRequestDelegateCallback,
+  useQueue as Boolean
+) {
+  $.log("Loading simple forecast for location..");
+
+  var language = $.getForecastLanguage();
+  var location = $.getLocation();
+
+  if (location == null) {
+    $.log("No location available. Not reloading location warning.");
+    return;
+  }
+
+  var now = Time.now();
+  var start = $.getFormattedDateForApiCall($.subtractDays(now, 2));
+  var end = $.getFormattedDateForApiCall($.addDays(now, 2));
+
+  var path = $.getSimpleWarningsPathForLocation(
+    location[0],
+    location[1],
+    language,
+    start,
+    end
+  );
+  var storageKey = $.simpleForecastCacheKeyForLocation;
 
   $.makeApiRequest(path, storageKey, callback, useQueue);
 }

--- a/skredvarselGarmin/source/backend/SkredvarselStorage.mc
+++ b/skredvarselGarmin/source/backend/SkredvarselStorage.mc
@@ -4,7 +4,7 @@ using Toybox.Application.Storage;
 
 const SelectedRegionIdsStorageKey = "selectedRegionIds";
 
-(:background)
+(:background,:glance)
 function getSimpleForecastCacheKeyForRegion(regionId as String) {
   return Lang.format("simple_$1$", [regionId]);
 }
@@ -13,6 +13,9 @@ function getSimpleForecastCacheKeyForRegion(regionId as String) {
 function getDetailedWarningsCacheKeyForRegion(regionId as String) {
   return Lang.format("detailed_$1$", [regionId]);
 }
+
+(:background,:glance)
+const simpleForecastCacheKeyForLocation = "location_simple_forecast";
 
 (:background)
 function getSelectedRegionIds() as Array<String> {

--- a/skredvarselGarmin/source/backend/WebRequestDelegate.mc
+++ b/skredvarselGarmin/source/backend/WebRequestDelegate.mc
@@ -5,8 +5,8 @@ using Toybox.Time;
 using Toybox.Application.Storage;
 using Toybox.WatchUi as Ui;
 
-//const FrontendBaseUrl = "http://localhost:5173";
-//const ApiBaseUrl = "https://localhost:8080/api";
+// const FrontendBaseUrl = "http://localhost:5173";
+// const ApiBaseUrl = "https://localhost:8080/api";
 const FrontendBaseUrl = "https://skredvarsel.app";
 const ApiBaseUrl = "https://skredvarsel.app/api";
 

--- a/skredvarselGarmin/source/types.mc
+++ b/skredvarselGarmin/source/types.mc
@@ -8,6 +8,14 @@ typedef SimpleAvalancheWarning as {
 
 typedef SimpleAvalancheForecast as Array<SimpleAvalancheWarning>;
 
+typedef LocationAvalancheForecast as {
+  "regionId" as Number,
+  "warnings" as SimpleAvalancheForecast,
+};
+
+typedef SimpleForecastData as SimpleAvalancheForecast or
+  LocationAvalancheForecast;
+
 typedef AvalancheProblem as {
   "typeName" as String,
   "exposedHeights" as Array<Number>,

--- a/skredvarselGarmin/source/utils/languageUtils.mc
+++ b/skredvarselGarmin/source/utils/languageUtils.mc
@@ -9,7 +9,8 @@ var useWatchLanguage as Boolean?;
 (:glance)
 function getUseWatchLanguage() as Boolean {
   if ($.useWatchLanguage == null) {
-    $.useWatchLanguage = Properties.getValue("useWatchLanguage");
+    $.useWatchLanguage =
+      Properties.getValue("useWatchLanguage") as Lang.Boolean;
   }
 
   return $.useWatchLanguage;

--- a/skredvarselGarmin/source/utils/locationUtils.mc
+++ b/skredvarselGarmin/source/utils/locationUtils.mc
@@ -1,0 +1,54 @@
+using Toybox.Activity;
+using Toybox.Weather;
+using Toybox.Lang;
+
+using Toybox.Application.Storage;
+using Toybox.Application.Properties;
+
+const LastLocationStorageKey = "last_location";
+
+(:glance,:background)
+var useLocation as Lang.Boolean?;
+
+(:glance,:background)
+function getUseLocation() as Lang.Boolean {
+  if ($.useLocation == null) {
+    $.useLocation = Properties.getValue("useLocation") as Lang.Boolean;
+  }
+
+  return $.useLocation;
+}
+
+(:background)
+function getLocation() as Lang.Array<Lang.Double>? {
+  // Get Location from Garmin Weather
+  if (Toybox has :Weather) {
+    var w = Weather.getCurrentConditions();
+    if (w != null && w.observationLocationPosition != null) {
+      $.log("Location obtained from Weather");
+      var loc = w.observationLocationPosition.toDegrees();
+      saveLocation(loc);
+      return loc;
+    }
+  }
+
+  // Get Location from Activity
+  var activityLoc = Activity.getActivityInfo().currentLocation;
+  if (activityLoc != null) {
+    $.log("Location obtained from Activity");
+    var loc = activityLoc.toDegrees();
+    saveLocation(loc);
+    return loc;
+  }
+
+  $.log("Location obtained from Storage.");
+  // Get last known Location
+  return Storage.getValue(LastLocationStorageKey);
+}
+
+(:background)
+function saveLocation(loc as Lang.Array<Lang.Double>) {
+  try {
+    Storage.setValue(LastLocationStorageKey, loc);
+  } catch (ex) {}
+}

--- a/skredvarselGarmin/source/utils/utils.mc
+++ b/skredvarselGarmin/source/utils/utils.mc
@@ -49,54 +49,58 @@ function getSortedRegionIds() as Array<String> {
 }
 
 (:glance)
-function getRegionName(regionId as String) as String {
-  if (regionId.equals("3003")) {
+function getRegionName(regionId as String or Number) as String {
+  if (regionId instanceof Lang.String) {
+    regionId = regionId.toNumber();
+  }
+
+  if (regionId == 3003) {
     return "Nordenskiöld Land";
-  } else if (regionId.equals("3006")) {
+  } else if (regionId == 3006) {
     return "Finnmarkskysten";
-  } else if (regionId.equals("3007")) {
+  } else if (regionId == 3007) {
     return "Vest-Finnmark";
-  } else if (regionId.equals("3009")) {
+  } else if (regionId == 3009) {
     return "Nord-Troms";
-  } else if (regionId.equals("3010")) {
+  } else if (regionId == 3010) {
     return "Lyngen";
-  } else if (regionId.equals("3011")) {
+  } else if (regionId == 3011) {
     return "Tromsø";
-  } else if (regionId.equals("3012")) {
+  } else if (regionId == 3012) {
     return "Sør-Troms";
-  } else if (regionId.equals("3013")) {
+  } else if (regionId == 3013) {
     return "Indre Troms";
-  } else if (regionId.equals("3014")) {
+  } else if (regionId == 3014) {
     return "Lofoten og Vesterålen";
-  } else if (regionId.equals("3015")) {
+  } else if (regionId == 3015) {
     return "Ofoten";
-  } else if (regionId.equals("3016")) {
+  } else if (regionId == 3016) {
     return "Salten";
-  } else if (regionId.equals("3017")) {
+  } else if (regionId == 3017) {
     return "Svartisen";
-  } else if (regionId.equals("3018")) {
+  } else if (regionId == 3018) {
     return "Helgeland";
-  } else if (regionId.equals("3022")) {
+  } else if (regionId == 3022) {
     return "Trollheimen";
-  } else if (regionId.equals("3023")) {
+  } else if (regionId == 3023) {
     return "Romsdal";
-  } else if (regionId.equals("3024")) {
+  } else if (regionId == 3024) {
     return "Sunnmøre";
-  } else if (regionId.equals("3027")) {
+  } else if (regionId == 3027) {
     return "Indre Fjordane";
-  } else if (regionId.equals("3028")) {
+  } else if (regionId == 3028) {
     return "Jotunheimen";
-  } else if (regionId.equals("3029")) {
+  } else if (regionId == 3029) {
     return "Indre Sogn";
-  } else if (regionId.equals("3031")) {
+  } else if (regionId == 3031) {
     return "Voss";
-  } else if (regionId.equals("3032")) {
+  } else if (regionId == 3032) {
     return "Hallingdal";
-  } else if (regionId.equals("3034")) {
+  } else if (regionId == 3034) {
     return "Hardanger";
-  } else if (regionId.equals("3035")) {
+  } else if (regionId == 3035) {
     return "Vest-Telemark";
-  } else if (regionId.equals("3037")) {
+  } else if (regionId == 3037) {
     return "Heiane";
   }
 
@@ -122,6 +126,7 @@ function getDeviceIdentifier() as String {
   return deviceSettings.uniqueIdentifier;
 }
 
+(:glance)
 function getDeviceScreenWidth() as Number {
   var deviceSettings = System.getDeviceSettings();
   return deviceSettings.screenWidth;


### PR DESCRIPTION
This commit adds support for location based forecast. The watch will use
the new location based endpoint from the backend to get the forecast for
the closest "Type A"-region. The location-based warning is completely
independent from the other warnings, and will end up in the glance and
above all the user-selected areas.