### PR TITLE
Automatically add watch.

### DIFF
--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Configuration/AuthenticationConfiguration.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Configuration/AuthenticationConfiguration.cs
@@ -25,7 +25,10 @@ public static class AuthenticationConfiguration
                 options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
             })
             .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options
-                => options.ExpireTimeSpan = TimeSpan.FromMinutes(60))
+                =>
+            {
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+            })
             .AddScheme<GarminAuthenticationSchemeOptions, GarminAuthenticationHandler>("Garmin", options => { })
             .AddGoogle(options =>
             {

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/AuthRouteBuilderExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Endpoints/AuthRouteBuilderExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Facebook;
 using Microsoft.AspNetCore.Authentication.Google;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Agreement.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Agreement.cs
@@ -9,6 +9,8 @@ public class Agreement
 
     public required Guid? CallbackId { get; set; }
 
+    public required string? WatchKey { get; set; }
+
     public required DateTime Created { get; set; }
 
     public required AgreementStatus Status { get; set; }

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Extensions/AgreementExtensions.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Entities/Extensions/AgreementExtensions.cs
@@ -7,9 +7,10 @@ public static class AgreementExtensions
         agreement.UserId = userId;
     }
 
-    public static void RemoveCallbackId(this Agreement agreement)
+    public static void RemoveCallbackIdAndWatchKey(this Agreement agreement)
     {
         agreement.CallbackId = null;
+        agreement.WatchKey = null;
     }
 
     public static void SetAsActive(this Agreement agreement)

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/AccountPage/AccountPage.tsx
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/AccountPage/AccountPage.tsx
@@ -7,17 +7,21 @@ import {
   DrawerContent,
   DrawerOverlay,
   Heading,
-  Text,
   Link,
+  Text,
 } from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import {
+  Link as RouterLink,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
+import { useNavigateOnClose } from "../../hooks/useNavigateOnClose";
 import { useUser } from "../../hooks/useUser";
+import { useAddWatch } from "../../hooks/useWatches";
 import { PersonalInfo } from "./PersonalInfo";
 import { Subscription } from "./Subscription";
 import { Watches } from "./Watches";
-import { Link as RouterLink } from "react-router-dom";
-import { useNavigateOnClose } from "../../hooks/useNavigateOnClose";
-import { useEffect } from "react";
 
 export const AccountPage = () => {
   const { data: user, isLoading: isLoadingUser } = useUser();
@@ -31,6 +35,25 @@ export const AccountPage = () => {
       navigate("/login");
     }
   }, [user, isLoadingUser]);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const watchKey = searchParams.get("watchKey");
+
+  const { mutate: mutateAddWatch, isPending: isAddWatchPending } = useAddWatch(
+    () => {
+      searchParams.delete("watchKey");
+      setSearchParams(searchParams, {
+        replace: true,
+        preventScrollReset: true,
+      });
+    },
+  );
+
+  useEffect(() => {
+    if (user && watchKey && !isAddWatchPending) {
+      mutateAddWatch(watchKey);
+    }
+  }, [mutateAddWatch, isAddWatchPending, user, watchKey]);
 
   return (
     <Drawer isOpen={!!user && !isClosing} onClose={onClose} size="md">

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/BuySubscriptionModal.tsx
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/BuySubscriptionModal.tsx
@@ -1,30 +1,30 @@
 import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalCloseButton,
-  ModalBody,
-  Text,
-  VStack,
   Box,
-  Icon,
   Center,
   Heading,
+  Icon,
   Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
 } from "@chakra-ui/react";
-import { Link as RouterLink } from "react-router-dom";
-import { VippsButton } from "./Buttons/VippsButton";
+import { ReactElement } from "react";
+import { FaPaperPlane } from "react-icons/fa";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { useEmailLogin } from "../hooks/useEmailLogin";
+import { useNavigateOnClose } from "../hooks/useNavigateOnClose";
+import { useNavigateToAccountIfLoggedIn } from "../hooks/useNavigateToAccountIfLoggedIn";
+import { useUser } from "../hooks/useUser";
 import { FacebookButton } from "./Buttons/FacebookButton";
 import { GoogleButton } from "./Buttons/GoogleButton";
-import { FaPaperPlane } from "react-icons/fa";
-import { useNavigateOnClose } from "../hooks/useNavigateOnClose";
-import { useUser } from "../hooks/useUser";
-import { useNavigateToAccountIfLoggedIn } from "../hooks/useNavigateToAccountIfLoggedIn";
-import { OrDivider } from "./OrDivider";
-import { useEmailLogin } from "../hooks/useEmailLogin";
+import { VippsButton } from "./Buttons/VippsButton";
 import { EmailLoginForm } from "./EmailLoginForm/EmailLoginForm";
-import { ReactElement } from "react";
+import { OrDivider } from "./OrDivider";
 
 type BuySubscriptionModalProps = {
   headerText?: string;
@@ -47,9 +47,12 @@ export const BuySubscriptionModal = (props: BuySubscriptionModalProps) => {
     ),
   } = props;
 
+  const [searchParams] = useSearchParams();
+  const watchKey = searchParams.get("watchKey");
+
   const { data: user, isLoading: isLoadingUser } = useUser();
 
-  useNavigateToAccountIfLoggedIn(user, isLoadingUser);
+  useNavigateToAccountIfLoggedIn(user, isLoadingUser, watchKey);
 
   const { isClosing, onClose } = useNavigateOnClose("/");
 
@@ -60,7 +63,7 @@ export const BuySubscriptionModal = (props: BuySubscriptionModalProps) => {
     handleEmailInputChange,
     handleSubmit,
     isPending,
-  } = useEmailLogin();
+  } = useEmailLogin(watchKey);
 
   return (
     <Modal isOpen={!isLoadingUser && !isClosing} onClose={onClose} isCentered>
@@ -83,7 +86,10 @@ export const BuySubscriptionModal = (props: BuySubscriptionModalProps) => {
                 </Box>
 
                 <VStack w="100%" alignItems="stretch">
-                  <VippsButton text="Kjøp abonnement med" />
+                  <VippsButton
+                    text="Kjøp abonnement med"
+                    link={`/createVippsAgreement${watchKey ? `?watchKey=${watchKey}` : ""}`}
+                  />
                 </VStack>
               </VStack>
 
@@ -104,8 +110,12 @@ export const BuySubscriptionModal = (props: BuySubscriptionModalProps) => {
                   </Heading>
                   <VStack gap={5} w="100%" alignItems="stretch">
                     <VStack gap={2} w="100%" alignItems="stretch">
-                      <GoogleButton link="/google-login?returnUrl=/account" />
-                      <FacebookButton link="/facebook-login?returnUrl=/account" />
+                      <GoogleButton
+                        link={`/google-login?returnUrl=/account${watchKey ? `?watchKey=${watchKey}` : ""}`}
+                      />
+                      <FacebookButton
+                        link={`/facebook-login?returnUrl=/account${watchKey ? `?watchKey=${watchKey}` : ""}`}
+                      />
                     </VStack>
 
                     <OrDivider text="Eller" />

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/LoginModal/LoginModal.tsx
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/Components/LoginModal/LoginModal.tsx
@@ -1,18 +1,16 @@
 import {
+  Box,
+  Icon,
   Modal,
-  ModalOverlay,
+  ModalBody,
+  ModalCloseButton,
   ModalContent,
   ModalHeader,
-  ModalCloseButton,
-  ModalBody,
-  Icon,
-  Box,
-  Center,
+  ModalOverlay,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { useNavigateOnClose } from "../../hooks/useNavigateOnClose";
-import { useState } from "react";
 import { LoginContent } from "./LoginContent";
 
 import { FaPaperPlane } from "react-icons/fa";
@@ -34,7 +32,7 @@ export const LoginModal = (props: LoginModalProps) => {
     handleEmailInputChange,
     handleSubmit,
     isPending,
-  } = useEmailLogin();
+  } = useEmailLogin(null);
 
   return (
     <Modal isOpen={!isClosing} onClose={onClose} isCentered>

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useEmailLogin.ts
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useEmailLogin.ts
@@ -1,11 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api";
-import { useMutation } from "@tanstack/react-query";
 
-export const sendLoginEmail = async (email: string) =>
-  api.post(`/email-login-send?email=${email}&returnUrl=/account`);
+export const sendLoginEmail = async (config: {
+  email: string;
+  watchKey: string | null;
+}) =>
+  api.post(
+    `/email-login-send?email=${config.email}&returnUrl=/account${config.watchKey ? `?watchKey=${config.watchKey}` : ""}`,
+  );
 
-export const useEmailLogin = () => {
+export const useEmailLogin = (watchKey: string | null) => {
   const [showSentEmail, setShowSentEmail] = useState(false);
 
   const [email, setEmail] = useState<string | undefined>(undefined);
@@ -30,7 +35,7 @@ export const useEmailLogin = () => {
     if (!email) {
       setError("Du må skrive en e-postadresse.");
     } else {
-      mutate(email);
+      mutate({ email, watchKey });
     }
   };
 

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useNavigateToAccountIfLoggedIn.ts
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useNavigateToAccountIfLoggedIn.ts
@@ -5,12 +5,13 @@ import { User } from "../types";
 export const useNavigateToAccountIfLoggedIn = (
   user: User | null | undefined,
   isLoadingUser: boolean,
+  watchKey: string | null,
 ) => {
   const navigate = useNavigate();
 
   useEffect(() => {
     if (user && !isLoadingUser) {
-      navigate("/account");
+      navigate(`/account${watchKey ? `?watchKey=${watchKey}` : ""}`);
     }
   }, [user, isLoadingUser]);
 };

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useWatches.ts
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Frontend/src/hooks/useWatches.ts
@@ -1,3 +1,4 @@
+import { useToast } from "@chakra-ui/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import { queryClient } from "../main";
@@ -13,13 +14,24 @@ export const useWatches = () =>
 
 const addWatch = (key: string) => api.post(`/api/watches/${key}`);
 
-export const useAddWatch = () =>
-  useMutation({
+export const useAddWatch = (onSuccess?: () => void) => {
+  const toast = useToast();
+
+  return useMutation({
     mutationFn: addWatch,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
+      toast({
+        title: "Klokke lagt til!",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      onSuccess?.();
     },
   });
+};
 
 const removeWatch = (id: string) => api.delete(`/api/watches/${id}`);
 

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Migrations/20250126165643_WatchKeyForAgreement.Designer.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Migrations/20250126165643_WatchKeyForAgreement.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using SkredvarselGarminWeb.Database;
 namespace SkredvarselGarminWeb.Migrations
 {
     [DbContext(typeof(SkredvarselDbContext))]
-    partial class SkredvarselDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250126165643_WatchKeyForAgreement")]
+    partial class WatchKeyForAgreement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Migrations/20250126165643_WatchKeyForAgreement.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Migrations/20250126165643_WatchKeyForAgreement.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SkredvarselGarminWeb.Migrations
+{
+    /// <inheritdoc />
+    public partial class WatchKeyForAgreement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "watch_key",
+                table: "agreements",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "watch_key",
+                table: "agreements");
+        }
+    }
+}

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Program.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddTransient<IUserService, UserService>();
 builder.Services.AddTransient<IStripeService, StripeService>();
 builder.Services.AddTransient<INotificationService, NotificationService>();
 builder.Services.AddTransient<IForecastAreaService, ForecastAreaService>();
+builder.Services.AddTransient<IWatchService, WatchService>();
 
 builder.Services.SetupAuthentication(authOptions!, googleOptions!, facebookOptions!);
 builder.Services.AddRefitClients(vippsOptions!);

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/IWatchService.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/IWatchService.cs
@@ -1,0 +1,9 @@
+using SkredvarselGarminWeb.Entities;
+
+namespace SkredvarselGarminWeb.Services;
+
+public interface IWatchService
+{
+    WatchAddRequest? GetWatchAddRequest(string watchAddKey);
+    void AddWatch(WatchAddRequest watchAddRequest, string userId);
+}

--- a/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/WatchService.cs
+++ b/SkredvarselGarminWeb/SkredvarselGarminWeb/Services/WatchService.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+using SkredvarselGarminWeb.Database;
+using SkredvarselGarminWeb.Entities;
+
+namespace SkredvarselGarminWeb.Services;
+
+public class WatchService(SkredvarselDbContext dbContext) : IWatchService
+{
+    public WatchAddRequest? GetWatchAddRequest(string watchAddKey)
+    {
+        return dbContext.WatchAddRequests.FirstOrDefault(r => EF.Functions.ILike(r.Key, watchAddKey));
+    }
+
+    public void AddWatch(WatchAddRequest watchAddRequest, string userId)
+    {
+        dbContext.Watches.Add(new Watch
+        {
+            Id = watchAddRequest.WatchId,
+            PartNumber = watchAddRequest.PartNumber,
+            UserId = userId
+        });
+
+        dbContext.WatchAddRequests.Remove(watchAddRequest);
+        dbContext.SaveChanges();
+    }
+}

--- a/skredvarselGarmin/source/SetupSubscriptionView/AddWatchView.mc
+++ b/skredvarselGarmin/source/SetupSubscriptionView/AddWatchView.mc
@@ -5,6 +5,8 @@ using Toybox.WatchUi as Ui;
 using Toybox.Timer;
 using Toybox.Communications as Comm;
 
+// This view is for when we have never seen the watch before.
+// Display a watchKey and redirect to web.
 class AddWatchView extends Ui.View {
   private var _textArea as Ui.TextArea?;
   private var _checkAddWatchTimer as Timer.Timer?;
@@ -17,7 +19,11 @@ class AddWatchView extends Ui.View {
     startTimer();
     _addWatchKey = addWatchKey;
 
-    Comm.openWebPage($.FrontendBaseUrl + "/addwatch", null, null);
+    Comm.openWebPage(
+      $.FrontendBaseUrl + "/addwatch?watchKey=" + addWatchKey,
+      null,
+      null
+    );
   }
 
   function onLayout(dc as Gfx.Dc) {

--- a/skredvarselGarmin/source/SetupSubscriptionView/InactiveSubscriptionView.mc
+++ b/skredvarselGarmin/source/SetupSubscriptionView/InactiveSubscriptionView.mc
@@ -5,6 +5,8 @@ using Toybox.WatchUi as Ui;
 using Toybox.Timer;
 using Toybox.Communications as Comm;
 
+// This view is for when we have the watch in the database, but
+// the watch is not subscribed.
 class InactiveSubscriptionView extends Ui.View {
   private var _textArea as Ui.TextArea?;
   private var _checkSubscriptionTimer as Timer.Timer?;

--- a/skredvarselGarmin/source/backend/WebRequestDelegate.mc
+++ b/skredvarselGarmin/source/backend/WebRequestDelegate.mc
@@ -6,7 +6,7 @@ using Toybox.Application.Storage;
 using Toybox.WatchUi as Ui;
 using Toybox.System;
 
-// const FrontendBaseUrl = "http://localhost:5173";
+// const FrontendBaseUrl = "https://localhost:5173";
 // const ApiBaseUrl = "https://localhost:8080/api";
 const FrontendBaseUrl = "https://skredvarsel.app";
 const ApiBaseUrl = "https://skredvarsel.app/api";


### PR DESCRIPTION
Change the behavior of the setup flow to allow automatically adding the watch when the user clicks the notification link. Do this by adding a watchKey query parameter to the link, and make sure to forward this all the way to the account page. If the user ends up on the account page with a watchKey-parameter, attempt to automatically add the watch.

Required reworking all the login flows as well as the vipps agreement flow. Add watchKey to the Agreement-entity as well to be able to pick it up when the user comes back from Vipps.